### PR TITLE
스타일 이슈

### DIFF
--- a/src/components/comment/write.tsx
+++ b/src/components/comment/write.tsx
@@ -69,7 +69,7 @@ const Write = ({ disabled, onSubmit }: Props) => {
       <textarea
         name="comment"
         id="comment"
-        className="block w-full resize-none border border-line p-4 text-sm text-subtle outline-0 placeholder:text-subtle/50 disabled:cursor-not-allowed"
+        className="block w-full resize-none border border-line p-4 text-subtle outline-0 placeholder:text-subtle/50 disabled:cursor-not-allowed"
         placeholder="댓글을 남겨주세요."
         value={comment.value}
         onChange={(e) => setComment((prev) => ({ ...prev, value: e.target.value }))}

--- a/src/components/typography/format.ts
+++ b/src/components/typography/format.ts
@@ -17,4 +17,4 @@ export const th = cn('p-2');
 export const td = cn('p-2');
 export const a = cn('text-link underline underline-offset-4');
 export const strong = cn('font-medium text-black dark:text-white');
-export const img = cn('m-auto my-4 aspect-auto h-auto w-full max-w-1/2 rounded-sm');
+export const img = cn('m-auto my-4 aspect-auto h-auto w-auto max-w-full rounded-sm');


### PR DESCRIPTION
- 모바일 사파리에서 `textarea`의 글꼴 크기가 16px 보다 작으면 확대되는 이슈
- 이미지 크기가 작게 보이는 이슈