### PR TITLE
이미지 사이즈

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,7 @@ import remarkGfm from 'remark-gfm';
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter';
 
 import { redirects } from './scripts/redirects.mjs';
+import rehypeImageSize from './scripts/rehype-image-size.mjs';
 import remarkPublicImage from './scripts/remark-public-image.mjs';
 import remarkToc from './scripts/remark-toc.mjs';
 
@@ -45,7 +46,7 @@ const withMDX = createMDX({
       remarkPublicImage,
       [remarkCodeHike, codehikeConfig],
     ],
-    rehypePlugins: [rehypeSlug, rehypeUnwrapImages],
+    rehypePlugins: [rehypeSlug, rehypeImageSize, rehypeUnwrapImages],
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "clsx": "^2.1.1",
     "codehike": "^1.0.7",
     "date-fns": "^4.1.0",
+    "image-size": "^2.0.2",
     "lottie-react": "^2.4.1",
     "next": "^15.3.5",
     "react": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      image-size:
+        specifier: ^2.0.2
+        version: 2.0.2
       lottie-react:
         specifier: ^2.4.1
         version: 2.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1551,6 +1554,11 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  image-size@2.0.2:
+    resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
+    engines: {node: '>=16.x'}
+    hasBin: true
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -4234,6 +4242,8 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  image-size@2.0.2: {}
 
   import-fresh@3.3.1:
     dependencies:

--- a/scripts/rehype-image-size.mjs
+++ b/scripts/rehype-image-size.mjs
@@ -1,0 +1,39 @@
+import { readFile } from 'fs/promises';
+import path from 'node:path';
+
+import sizeOf from 'image-size';
+import { visit } from 'unist-util-visit';
+
+const dir = path.join(process.cwd(), 'public');
+
+const rehypeImageSize = () => {
+  return async (tree) => {
+    const promises = [];
+
+    visit(tree, 'element', (node) => {
+      if (node.tagName !== 'img') return;
+
+      const { src, width, height } = node.properties;
+
+      if (src && !(width && height)) {
+        const filePath = path.join(dir, src);
+
+        const promise = (async () => {
+          const buffer = await readFile(filePath);
+          const dimensions = sizeOf(buffer);
+
+          if (dimensions.width && dimensions.height) {
+            node.properties.width = width;
+            node.properties.height = height;
+          }
+        })();
+
+        promises.push(promise);
+      }
+    });
+
+    await Promise.all(promises);
+  };
+};
+
+export default rehypeImageSize;

--- a/src/components/typography/format.ts
+++ b/src/components/typography/format.ts
@@ -17,5 +17,5 @@ export const th = cn('p-2');
 export const td = cn('p-2');
 export const a = cn('underline underline-offset-4');
 export const strong = cn('font-bold');
-export const img = cn('h-auto w-full rounded');
+export const img = cn('mx-auto rounded');
 export const pre = cn('text-sm leading-6');

--- a/src/components/typography/img.tsx
+++ b/src/components/typography/img.tsx
@@ -11,7 +11,6 @@ const Img = (props: ImageProps) => {
         width={props.width || 0}
         height={props.height || 0}
         sizes="(max-width: 768px) 100vw, (max-width: 1200px) 80vw, 70vw"
-        priority
         alt=""
         unoptimized={isUnoptimized}
       />


### PR DESCRIPTION
- `rehype-image-size` 플러그인 추가
  - 빌드 타임에 MDX에서 추가한 이미지의 사이즈를 읽어서 속성에 추가해주는 플러그인
  - `next/image`에서 사용